### PR TITLE
post-create-hook

### DIFF
--- a/bin/post-create-hook
+++ b/bin/post-create-hook
@@ -1,0 +1,10 @@
+#! /bin/bash
+#
+# post-create-hook
+#
+#     $1 id (name)
+#     $2 root volume path
+#
+
+echo $1, $2 > /tmp/out.txt
+exit 0

--- a/libvirt/virtual_machine_repository.go
+++ b/libvirt/virtual_machine_repository.go
@@ -491,6 +491,10 @@ func (repo *VirtualMachineRepository) Create(id string, arch compute.Arch, vcpus
 	if err != nil {
 		return nil, util.NewError(err, "cannot parse domain to vm")
 	}
+	cmd := exec.Command("post-create-hook", id, volumes)
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
 	return vm, nil
 }
 

--- a/libvirt/virtual_machine_repository.go
+++ b/libvirt/virtual_machine_repository.go
@@ -491,10 +491,16 @@ func (repo *VirtualMachineRepository) Create(id string, arch compute.Arch, vcpus
 	if err != nil {
 		return nil, util.NewError(err, "cannot parse domain to vm")
 	}
-	cmd := exec.Command("post-create-hook", id, volumes)
-	if err := cmd.Run(); err != nil {
-		return nil, err
-	}
+
+        logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+        logger.Info().Str(id, volumes[0].Path).Msg("Executing post-create-hook on vm:")
+
+        //ASSUMPTION: since this is executed during VM creation the first (and only) volume is the root
+        cmd := exec.Command("post-create-hook", id, volumes[0].Path)
+        if err := cmd.Run(); err != nil {
+                logger.Error().Msg("Error executing post-create-hook")
+        }
+	
 	return vm, nil
 }
 


### PR DESCRIPTION
heh, my commits in the fork are called post-commit-hook.  This IS similar to a post-commit-hook in svn.

This is also my first go code.  

Not sure if you'd even want this, but since I was the one that asked for it... here it is.  I needed it so I can run virt-customize on the newly created image.

This resolves #26  
